### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/organizacionNikols/90c1e015-0a4d-4b1a-9eb3-b76f4ba68702/8814abd8-4821-4491-ad19-b735196d9bce/_apis/work/boardbadge/844d6043-f8e0-43f5-805c-1a0c8f60d0d9)](https://dev.azure.com/organizacionNikols/90c1e015-0a4d-4b1a-9eb3-b76f4ba68702/_boards/board/t/8814abd8-4821-4491-ad19-b735196d9bce/Microsoft.RequirementCategory)
 # green_pure_
 
 A new Flutter project.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#69](https://dev.azure.com/organizacionNikols/90c1e015-0a4d-4b1a-9eb3-b76f4ba68702/_workitems/edit/69). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.